### PR TITLE
[rustash] async CRUD operations

### DIFF
--- a/crates/rustash-cli/src/commands/add.rs
+++ b/crates/rustash-cli/src/commands/add.rs
@@ -67,10 +67,10 @@ impl AddCommand {
             anyhow::bail!("Content cannot be empty for CLI usage.");
         }
 
-        let mut conn = db::get_connection().await?;
+        let pool = db::get_pool().await?;
         let new_snippet =
             Snippet::with_uuid(Uuid::new_v4(), title.clone(), content, self.tags.clone());
-        let snippet = add_snippet(&mut *conn, new_snippet)?;
+        let snippet = add_snippet(&pool, new_snippet).await?;
         println!(
             "✓ Added snippet '{}' with ID: {}",
             snippet.title, snippet.uuid
@@ -94,14 +94,14 @@ impl AddCommand {
         // It returns data for the new snippet if the user saved it.
         if let Some(new_snippet_data) = gui::show_add_window()? {
             // The GUI returns the data; the CLI is responsible for saving it.
-            let mut conn = db::get_connection().await?;
+            let pool = db::get_pool().await?;
             let snippet_to_add = Snippet::with_uuid(
                 Uuid::new_v4(),
                 new_snippet_data.title,
                 new_snippet_data.content,
                 new_snippet_data.tags,
             );
-            add_snippet(&mut *conn, snippet_to_add)?;
+            add_snippet(&pool, snippet_to_add).await?;
             println!("✓ Snippet added via GUI.");
         } else {
             println!("Operation cancelled.");

--- a/crates/rustash-cli/src/commands/list.rs
+++ b/crates/rustash-cli/src/commands/list.rs
@@ -36,15 +36,16 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub async fn execute(self) -> Result<()> {
-        let mut conn = db::get_connection().await?;
+        let pool = db::get_pool().await?;
 
         // Get snippets with filtering and searching
         let snippets = list_snippets_with_tags(
-            &mut *conn,
+            &pool,
             self.filter.as_deref(),
             self.tag.as_deref(),
             Some(self.limit),
-        )?;
+        )
+        .await?;
 
         if snippets.is_empty() {
             println!("No snippets found.");

--- a/crates/rustash-cli/src/commands/use_snippet.rs
+++ b/crates/rustash-cli/src/commands/use_snippet.rs
@@ -36,7 +36,7 @@ pub struct UseCommand {
 
 impl UseCommand {
     pub async fn execute(self) -> Result<()> {
-        let mut conn = db::get_connection().await?;
+        let pool = db::get_pool().await?;
 
         // Parse UUID and get the snippet
         let _snippet_uuid = self
@@ -44,7 +44,8 @@ impl UseCommand {
             .parse::<Uuid>()
             .with_context(|| format!("Invalid UUID: {}", self.uuid))?;
 
-        let snippet = get_snippet_by_id(&mut *conn, &self.uuid)?
+        let snippet = get_snippet_by_id(&pool, &self.uuid)
+            .await?
             .ok_or_else(|| anyhow::anyhow!("Snippet with UUID {} not found", self.uuid))?;
 
         let snippet_with_tags = SnippetWithTags::from(snippet);

--- a/crates/rustash-cli/src/db.rs
+++ b/crates/rustash-cli/src/db.rs
@@ -79,3 +79,12 @@ pub async fn get_connection() -> anyhow::Result<DbConnection> {
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
     Ok(DbConnection::from(conn))
 }
+
+/// Get a clone of the global connection pool
+pub async fn get_pool() -> anyhow::Result<Arc<DbPool>> {
+    let pool_guard = DB_POOL.lock().unwrap();
+    let pool = pool_guard
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Database pool not initialized"))?;
+    Ok(pool.clone())
+}


### PR DESCRIPTION
## Summary
- refactor CRUD functions in `rustash-core` to be async and accept `DbPool`
- adjust CLI to use new async APIs and expose `get_pool`
- migrate helper functions to use `diesel_async::RunQueryDsl`

## Testing
- `cargo fmt --all` *(fails: `search.rs` missing)*
- `cargo clippy --all -- --deny warnings` *(fails: rustc 1.87 unsupported)*
- `cargo test --workspace` *(fails: rustc 1.87 unsupported)*

------
https://chatgpt.com/codex/tasks/task_b_686dbc7aedb08330a9ebdff85ee07c07