### PR TITLE
[rustash] fix get_related query variable names

### DIFF
--- a/crates/rustash-core/src/storage/postgres.rs
+++ b/crates/rustash-core/src/storage/postgres.rs
@@ -351,11 +351,10 @@ impl StorageBackend for PostgresBackend {
                     Box::new(id_str) as Box<dyn diesel::query_builder::QueryFragment<Pg> + Send>
                 ]
             )
-            (sql, param_refs)
         };
 
         // Execute the query
-        let rows = conn.query(&sql, &param_refs[..]).await?;
+        let rows = conn.query(&query, &params[..]).await?;
 
         // Process results
         let mut results = Vec::new();


### PR DESCRIPTION
## Summary
- correct local variables in `get_related`

## Testing
- `cargo fmt --all` *(fails: file for module `database` found at both `crates/rustash-core/src/database.rs` and `crates/rustash-core/src/database/mod.rs`)*
- `cargo clippy --all -- --deny warnings` *(fails: file for module `database` found at both paths)*
- `cargo test --workspace` *(fails: file for module `database` found at both paths)*

------
https://chatgpt.com/codex/tasks/task_b_6872fefabd3c8330a7cbc6605d36476f