### PR TITLE
[rustash] document stashes and new CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Rustash helps you manage, search, and use code snippets efficiently across multi
   - SQLite for local development (default)
   - PostgreSQL with Apache AGE for graph capabilities
   - In-memory backend for testing
+  - Named *Stashes* choose which backend to use via `stashes.toml`
 
 - **Powerful Snippet Management**
   - Full-text search with advanced filtering
@@ -44,31 +45,49 @@ cargo install --path .
 
 ```bash
 # Add a new snippet
-rustash add "Docker Run PostgreSQL" \
+rustash --stash main snippets add "Docker Run PostgreSQL" \
   "docker run --name postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d postgres" \
   --tags docker,postgres
 
 # List snippets
-rustash list
+rustash --stash main snippets list
 
 # Search snippets
-rustash list --filter "postgres"
+rustash --stash main snippets list --filter "postgres"
 
 # Use a snippet (copies to clipboard)
-rustash use 1
+rustash --stash main snippets use 1
 ```
 
 ### Using Template Variables
 
 ```bash
 # Add a snippet with placeholders
-rustash add "Git Commit" "git commit -m '{{message}}'" --tags git
+rustash --stash main snippets add "Git Commit" "git commit -m '{{message}}'" --tags git
 
 # Use with variables
-rustash use 1 --var message="feat: Add new feature"
+rustash --stash main snippets use 1 --var message="feat: Add new feature"
 
 # Or use interactive mode
-rustash use 1 --interactive
+rustash --stash main snippets use 1 --interactive
+```
+
+### Stashes
+
+Stashes are named collections of data. Define them in `~/.config/rustash/stashes.toml`:
+
+```toml
+default_stash = "main"
+
+[stashes.main]
+service_type = "Snippet"
+database_url = "sqlite://~/.config/rustash/rustash.db"
+```
+
+Use the `--stash` flag to target one:
+
+```bash
+rustash --stash main snippets list
 ```
 
 ## 📚 Documentation

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -49,19 +49,19 @@ export DATABASE_URL=~/.local/share/rustash/snippets.db
 
 1. **Add a snippet**:
    ```bash
-   rustash add "Docker Run PostgreSQL" \
+   rustash --stash main snippets add "Docker Run PostgreSQL" \
      "docker run --name postgres -e POSTGRES_PASSWORD=secret -p 5432:5432 -d postgres" \
      --tags docker,postgres
    ```
 
 2. **List your snippets**:
    ```bash
-   rustash list
+   rustash --stash main snippets list
    ```
 
 3. **Use a snippet** (copies to clipboard):
    ```bash
-   rustash use 1
+   rustash --stash main snippets use 1
    ```
 
 ### Using Variables in Snippets
@@ -70,13 +70,31 @@ Create templates with placeholders:
 
 ```bash
 # Add a snippet with placeholders
-rustash add "SSH Command" "ssh {{user}}@{{host}} -p {{port:22}}" --tags ssh
+rustash --stash main snippets add "SSH Command" "ssh {{user}}@{{host}} -p {{port:22}}" --tags ssh
 
 # Use with variables
-rustash use 2 --var user=admin --var host=example.com
+rustash --stash main snippets use 2 --var user=admin --var host=example.com
 
 # Or use interactive mode
-rustash use 2 --interactive
+rustash --stash main snippets use 2 --interactive
+```
+
+### Stashes
+
+Stashes are defined in `~/.config/rustash/stashes.toml`:
+
+```toml
+default_stash = "main"
+
+[stashes.main]
+service_type = "Snippet"
+database_url = "sqlite://~/.config/rustash/rustash.db"
+```
+
+CLI syntax:
+
+```bash
+rustash --stash <name> <service> <command>
 ```
 
 ## 📚 Core Concepts
@@ -85,8 +103,15 @@ rustash use 2 --interactive
 - **Placeholders**: Dynamic variables (`{{name}}`) that can be filled in when using a snippet
 - **Tags**: Labels for organizing and filtering snippets
 - **Search**: Find snippets using full-text search or tag filtering
+- **Stashes**: Named collections with their own backend, configured in `~/.config/rustash/stashes.toml`
 
 ## ⌨️ Command Reference
+
+All commands follow:
+
+```bash
+rustash --stash <name> <service> <command> [options]
+```
 
 ### Add Snippets
 

--- a/crates/rustash-cli/src/commands/add.rs
+++ b/crates/rustash-cli/src/commands/add.rs
@@ -50,12 +50,19 @@ impl AddCommand {
             self.content.unwrap_or_default()
         };
 
-        anyhow::ensure!(!title.trim().is_empty(), "Title cannot be empty for CLI usage.");
-        anyhow::ensure!(!content.trim().is_empty(), "Content cannot be empty for CLI usage.");
+        anyhow::ensure!(
+            !title.trim().is_empty(),
+            "Title cannot be empty for CLI usage."
+        );
+        anyhow::ensure!(
+            !content.trim().is_empty(),
+            "Content cannot be empty for CLI usage."
+        );
 
-        let new_snippet = Snippet::with_uuid(Uuid::new_v4(), title.clone(), content, self.tags.clone());
+        let new_snippet =
+            Snippet::with_uuid(Uuid::new_v4(), title.clone(), content, self.tags.clone());
         backend.save(&new_snippet).await?;
-        println!("\u2713 Added snippet '{}' to stash.", new_snippet.title);
+        println!("\u{2713} Added snippet '{}' to stash.", new_snippet.title);
         Ok(())
     }
 
@@ -65,7 +72,7 @@ impl AddCommand {
         if let Some(data) = gui::show_add_window()? {
             let snippet = Snippet::with_uuid(Uuid::new_v4(), data.title, data.content, data.tags);
             backend.save(&snippet).await?;
-            println!("\u2713 Snippet added via GUI.");
+            println!("\u{2713} Snippet added via GUI.");
         } else {
             println!("Operation cancelled.");
         }

--- a/crates/rustash-cli/src/commands/use_snippet.rs
+++ b/crates/rustash-cli/src/commands/use_snippet.rs
@@ -27,9 +27,16 @@ pub struct UseCommand {
 impl UseCommand {
     pub async fn execute(self, backend: Arc<Box<dyn StorageBackend>>) -> Result<()> {
         let snippet_uuid = self.uuid.parse::<Uuid>().context("Invalid UUID format")?;
-        
-        let snippet_dyn = backend.get(&snippet_uuid).await?.context("Snippet not found")?;
-        let snippet = snippet_dyn.as_any().downcast_ref::<SnippetWithTags>().context("Internal error: Could not downcast to SnippetWithTags")?.clone();
+
+        let snippet_dyn = backend
+            .get(&snippet_uuid)
+            .await?
+            .context("Snippet not found")?;
+        let snippet = snippet_dyn
+            .as_any()
+            .downcast_ref::<SnippetWithTags>()
+            .context("Internal error: Could not downcast to SnippetWithTags")?
+            .clone();
 
         let mut variables: HashMap<String, String> = self.var.into_iter().collect();
         let placeholders = extract_placeholders(&snippet.content);
@@ -37,7 +44,9 @@ impl UseCommand {
         if self.interactive {
             for placeholder in &placeholders {
                 if !variables.contains_key(placeholder) {
-                    let value: String = Input::new().with_prompt(format!("Enter value for '{}'", placeholder)).interact_text()?;
+                    let value: String = Input::new()
+                        .with_prompt(format!("Enter value for '{}'", placeholder))
+                        .interact_text()?;
                     variables.insert(placeholder.clone(), value);
                 }
             }
@@ -50,7 +59,7 @@ impl UseCommand {
         } else {
             println!("Snippet: {}", snippet.title);
             copy_to_clipboard(&expanded_content)?;
-            println!("\n\u2713 Copied to clipboard");
+            println!("\n\u{2713} Copied to clipboard");
         }
 
         Ok(())
@@ -68,7 +77,10 @@ fn parse_variable(s: &str) -> Result<(String, String), String> {
 
 fn extract_placeholders(content: &str) -> Vec<String> {
     let re = Regex::new(r"\{\{\s*(\w+)\s*\}\}").unwrap();
-    let mut placeholders: Vec<String> = re.captures_iter(content).map(|cap| cap[1].to_string()).collect();
+    let mut placeholders: Vec<String> = re
+        .captures_iter(content)
+        .map(|cap| cap[1].to_string())
+        .collect();
     placeholders.sort();
     placeholders.dedup();
     placeholders


### PR DESCRIPTION
## Summary
- introduce Stash concept in `README.md`
- document stashes config and CLI usage in `README.md`
- update quick start examples with `--stash`
- add Stash section to `USER_GUIDE.md`
- show CLI syntax and config
- fix unicode escape sequences in CLI output strings

## Testing
- `cargo fmt --all` *(fails: failed to resolve mod `database`)*
- `cargo clippy --all -- --deny warnings` *(fails: could not compile `rustash-core`)*
- `cargo test --workspace` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_6872fefc497c833089d96dee083a6f73