### PR TITLE
[rustash] connect CLI snippet commands to backend

### DIFF
--- a/crates/rustash-cli/src/commands/list.rs
+++ b/crates/rustash-cli/src/commands/list.rs
@@ -33,7 +33,11 @@ impl ListCommand {
         let snippets_dyn = backend.query(&query).await?;
         let snippets: Vec<_> = snippets_dyn
             .iter()
-            .filter_map(|item| item.as_any().downcast_ref::<rustash_core::SnippetWithTags>().cloned())
+            .filter_map(|item| {
+                item.as_any()
+                    .downcast_ref::<rustash_core::models::SnippetWithTags>()
+                    .cloned()
+            })
             .collect();
 
         if snippets.is_empty() {

--- a/crates/rustash-cli/src/commands/snippets.rs
+++ b/crates/rustash-cli/src/commands/snippets.rs
@@ -1,16 +1,15 @@
 // crates/rustash-cli/src/commands/snippets.rs
-use super::SnippetCommands;
+use super::{SnippetCommand, SnippetCommands};
 use anyhow::Result;
 use rustash_core::storage::StorageBackend;
 use std::sync::Arc;
 
-pub async fn execute_snippet_command(
-    command: SnippetCommands,
-    backend: Arc<Box<dyn StorageBackend>>,
-) -> Result<()> {
-    match command {
-        SnippetCommands::Add(cmd) => cmd.execute(backend).await,
-        SnippetCommands::List(cmd) => cmd.execute(backend).await,
-        SnippetCommands::Use(cmd) => cmd.execute(backend).await,
+impl SnippetCommand {
+    pub async fn execute(self, backend: Arc<Box<dyn StorageBackend>>) -> Result<()> {
+        match self.command {
+            SnippetCommands::Add(cmd) => cmd.execute(backend).await,
+            SnippetCommands::List(cmd) => cmd.execute(backend).await,
+            SnippetCommands::Use(cmd) => cmd.execute(backend).await,
+        }
     }
 }

--- a/crates/rustash-cli/src/main.rs
+++ b/crates/rustash-cli/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
                 stash.name,
                 stash.config.service_type
             );
-            commands::snippets::execute_snippet_command(cmd.command, stash.backend.clone()).await?;
+            cmd.execute(stash.backend.clone()).await?;
         }
         Commands::Stash(cmd) => {
             commands::stash_cmds::execute_stash_command(cmd.command, config).await?;

--- a/crates/rustash-core/src/stash.rs
+++ b/crates/rustash-core/src/stash.rs
@@ -3,6 +3,7 @@
 use crate::storage::StorageBackend;
 use crate::Result;
 use serde::Deserialize;
+use std::sync::Arc;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum ServiceType {
@@ -21,13 +22,13 @@ pub struct StashConfig {
 pub struct Stash {
     pub name: String,
     pub config: StashConfig,
-    pub backend: Box<dyn StorageBackend>,
+    pub backend: Arc<Box<dyn StorageBackend>>,
 }
 
 impl Stash {
     /// Creates a new, initialized Stash by setting up its backend.
     pub async fn new(name: &str, config: StashConfig) -> Result<Self> {
-        let backend = crate::create_backend(&config.database_url).await?;
+        let backend = Arc::new(crate::create_backend(&config.database_url).await?);
         Ok(Self {
             name: name.to_string(),
             config,


### PR DESCRIPTION
## Summary
- connect snippet command executor to pass backend
- use trait backend in snippet list command
- provide backend access via `Stash` object

## Testing
- `cargo clippy --all -- --deny warnings` *(fails: lint groups priority and unresolved imports)*
- `cargo test --workspace` *(fails to compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_6873108bf9fc8330b987b2eae537c6ad