### PR TITLE
[rustash] cleanup command modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ cargo install --path .
 
 ```bash
 # Add a new snippet
-rustash --stash main snippets add "Docker Run PostgreSQL" \
-  "docker run --name postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d postgres" \
-  --tags docker,postgres
+rustash --stash main snippets add "Title" "Content"
 
 # List snippets
 rustash --stash main snippets list

--- a/crates/rustash-cli/src/commands/mod.rs
+++ b/crates/rustash-cli/src/commands/mod.rs
@@ -1,36 +1,10 @@
 //! CLI commands module
 
-use clap::{Args, Subcommand};
-
-// Command modules
+// Command-line argument definitions
 pub mod add;
 pub mod list;
-pub mod snippets;
 pub mod stash_cmds;
 pub mod use_snippet;
 
-// --- Top-level Command Groups ---
-
-#[derive(Args)]
-pub struct SnippetCommand {
-    #[command(subcommand)]
-    pub command: SnippetCommands,
-}
-
-#[derive(Args)]
-pub struct StashCommand {
-    #[command(subcommand)]
-    pub command: stash_cmds::StashCommands,
-}
-
-// --- Subcommands for Snippets ---
-
-#[derive(Subcommand)]
-pub enum SnippetCommands {
-    /// Add a new snippet
-    Add(add::AddCommand),
-    /// List and search snippets
-    List(list::ListCommand),
-    /// Use a snippet (expand and copy to clipboard)
-    Use(use_snippet::UseCommand),
-}
+// Command logic/execution modules
+pub mod snippets;

--- a/crates/rustash-cli/src/commands/snippets.rs
+++ b/crates/rustash-cli/src/commands/snippets.rs
@@ -1,8 +1,24 @@
-// crates/rustash-cli/src/commands/snippets.rs
-use super::{SnippetCommand, SnippetCommands};
+use super::{add::AddCommand, list::ListCommand, use_snippet::UseCommand};
 use anyhow::Result;
+use clap::{Args, Subcommand};
 use rustash_core::storage::StorageBackend;
 use std::sync::Arc;
+
+#[derive(Args)]
+pub struct SnippetCommand {
+    #[command(subcommand)]
+    pub command: SnippetCommands,
+}
+
+#[derive(Subcommand)]
+pub enum SnippetCommands {
+    /// Add a new snippet
+    Add(AddCommand),
+    /// List and search snippets
+    List(ListCommand),
+    /// Use a snippet (expand and copy to clipboard)
+    Use(UseCommand),
+}
 
 impl SnippetCommand {
     pub async fn execute(self, backend: Arc<Box<dyn StorageBackend>>) -> Result<()> {


### PR DESCRIPTION
## Summary
- streamline CLI command modules
- update README with new CLI usage

## Testing
- `cargo check --workspace --features sqlite,postgres` *(fails: could not compile `rustash-core`)*
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings` *(fails: could not compile `xtask`)*
- `cargo test --workspace` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_687313ede61c8330aecba7f05d0f9756