### PR TITLE
[rustash] add developer docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,7 +173,7 @@ The project's investment in DevX is a significant strength.
 
 *   **AI-Driven Workflow**: The PRP system is a sophisticated and powerful way to ensure high-quality, consistent contributions. It's a defining feature of this project.
 *   **`xtask` Build System**: Using `cargo xtask` for build automation is a modern Rust best practice. It keeps all build logic in Rust and is more flexible than shell scripts.
-*   **Documentation**: The project has a good set of documentation. To make it even better, we should create a central **`DEVELOPER_GUIDE.md`** that serves as an entry point for new contributors, linking to this `ARCHITECTURE.md`, `CONTRIBUTING_WITH_AI.md`, and other relevant resources.
+*   **Documentation**: The project has a consolidated **[`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md)** which links to this `ARCHITECTURE.md`, `CONTRIBUTING_WITH_AI.md`, and other resources.
 
 ## 6. Architectural Roadmap
 

--- a/CONTRIBUTING_WITH_AI.md
+++ b/CONTRIBUTING_WITH_AI.md
@@ -1,6 +1,6 @@
 # Contributing to Rustash with AI
 
-Welcome to the Rustash project! This document outlines our innovative AI-driven development methodology that leverages Product Requirement Prompts (PRPs) to guide development. This approach helps maintain consistency, quality, and efficiency across the codebase.
+Welcome to the Rustash project! This document outlines our innovative AI-driven development methodology that leverages Product Requirement Prompts (PRPs) to guide development. This approach helps maintain consistency, quality, and efficiency across the codebase. For general setup instructions see [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md).
 
 ## Table of Contents
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,19 @@
+# 🛠️ Rustash Developer Guide
+
+A quickstart for contributors. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for in-depth design notes.
+
+## Setup
+- Install the Rust toolchain with `rustup`.
+- Add `clippy` and `rustfmt`: `rustup component add clippy rustfmt`.
+- Fetch workspace dependencies: `cargo fetch`.
+
+## Workflow
+- Format: `cargo fmt --all`.
+- Lint: `cargo clippy --all -- --deny warnings`.
+- Test: `cargo test --workspace`.
+- Use `make` targets for database-backed tests.
+
+## More Documentation
+- [User Guide](USER_GUIDE.md)
+- [Architecture](ARCHITECTURE.md)
+- [AI Contribution Guide](CONTRIBUTING_WITH_AI.md)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ rustash --stash my-snippets snippets list
 |----------|-------------|
 | [USER_GUIDE.md](USER_GUIDE.md) | Complete guide to using the Rustash CLI and managing stashes. |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and design decisions. |
+| [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) | Setup and workflow for contributors. |
 | [CONTRIBUTING_WITH_AI.md](CONTRIBUTING_WITH_AI.md) | How we use AI in our development process. |
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Summary
- add `DEVELOPER_GUIDE.md` with setup steps
- link new guide from `README.md`
- reference guide from `ARCHITECTURE.md` and `CONTRIBUTING_WITH_AI.md`

## Testing
- `cargo fmt --all`
- `cargo clippy --all -- --deny warnings` *(fails: trait not dyn compatible)*
- `cargo test --workspace` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_b_68732f38950883308e3995680bb4f4ef