### PR TITLE
[rustash] remove r2d2 dependency

### DIFF
--- a/crates/rustash-core/Cargo.toml
+++ b/crates/rustash-core/Cargo.toml
@@ -12,10 +12,9 @@ categories.workspace = true
 
 [dependencies]
 # Core
-diesel = { workspace = true, features = ["chrono", "serde_json", "uuid", "r2d2"] }
+diesel = { workspace = true, features = ["chrono", "serde_json", "uuid"] }
 diesel_migrations = { workspace = true }
 diesel-async = { version = "0.5", default-features = false, features = ["postgres", "sqlite", "bb8"] }
-r2d2 = { version = "0.8" }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary
- drop `r2d2` from dependencies
- stop enabling diesel's `r2d2` feature
- `cargo check` fails but shows compilation attempted without r2d2

## Testing
- `cargo fmt --manifest-path crates/rustash-core/Cargo.toml`
- `cargo clippy --all -- --deny warnings` *(fails: could not compile `rustash-core`)*
- `cargo check` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_68740b386f9c8330953301d1aa2f50b8