### PR TITLE
[rustash] derive Serialize for ServiceType

### DIFF
--- a/crates/rustash-core/src/stash.rs
+++ b/crates/rustash-core/src/stash.rs
@@ -2,10 +2,10 @@
 
 use crate::storage::StorageBackend;
 use crate::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ServiceType {
     Snippet,
     RAG,


### PR DESCRIPTION
## Summary
- allow ServiceType to serialize

## Testing
- `cargo fmt --all`
- `cargo clippy --all -- --deny warnings` *(fails: could not compile `rustash-core`)*
- `cargo test --workspace` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_68740b393a888330b5b69ab5db1ddefa