### PR TITLE
[rustash] fix tag filter field name

### DIFF
--- a/crates/rustash-core/src/storage/postgres.rs
+++ b/crates/rustash-core/src/storage/postgres.rs
@@ -145,7 +145,7 @@ impl StorageBackend for PostgresBackend {
         }
         
         // Apply tags filter if provided
-        if let Some(tags) = &query.tags_filter {
+        if let Some(tags) = &query.tags {
             if !tags.is_empty() {
                 use diesel::dsl::sql;
                 let tags_json = serde_json::to_value(tags)?;
@@ -326,9 +326,9 @@ impl StorageBackend for PostgresBackend {
             .collect();
             
         Ok(results)
-        */
     }
 
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -466,8 +466,9 @@ mod tests {
         // Test text search
         let query = crate::models::Query {
             text_filter: Some("queries".to_string()),
-            tags_filter: None,
+            tags: None,
             limit: Some(10),
+            ..Default::default()
         };
         let results = backend.query(&query).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -480,8 +481,9 @@ mod tests {
         // Test tag filter
         let query = crate::models::Query {
             text_filter: None,
-            tags_filter: Some(vec!["query".to_string()]),
+            tags: Some(vec!["query".to_string()]),
             limit: Some(10),
+            ..Default::default()
         };
         let results = backend.query(&query).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -605,5 +607,4 @@ mod tests {
 
         assert_eq!(related_snippet.title, "Related Snippet");
     }
-}
 }

--- a/crates/rustash-core/src/storage/sqlite.rs
+++ b/crates/rustash-core/src/storage/sqlite.rs
@@ -376,8 +376,9 @@ mod tests {
 
         let query = crate::models::Query {
             text_filter: Some("vector".to_string()),
-            tags_filter: None,
+            tags: None,
             limit: Some(10),
+            ..Default::default()
         };
 
         let results = backend.query(&query).await.unwrap();


### PR DESCRIPTION
## Summary
- fix field name in Postgres query filter
- update tests for new `tags` field
- adjust SQLite tests to use `tags`

## Testing
- `cargo clippy --all -- --deny warnings` *(fails: could not compile `rustash-core`)*
- `cargo test --workspace` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_68755a62d9c48330a2debf062e95102c