### PR TITLE
[rustash] remove unused Backend import

### DIFF
--- a/crates/rustash-core/src/models.rs
+++ b/crates/rustash-core/src/models.rs
@@ -3,7 +3,6 @@
 use crate::memory::MemoryItem;
 use crate::schema::snippets;
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
-use diesel::backend::Backend;
 use diesel::prelude::*;
 use diesel::sql_types::{Text, Timestamp};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary
- clean up unused `Backend` import in `models.rs`

## Testing
- `cargo fmt --all` *(fails: cannot parse `postgres.rs`)*
- `cargo clippy --all -- --deny warnings` *(fails: could not compile `rustash-core`)*

------
https://chatgpt.com/codex/tasks/task_b_687567033eb8833096b75daf5d2e6580