### PR TITLE
[rustash] Apply user-provided database backend fixes

### DIFF
--- a/crates/rustash-core/src/database/mod.rs
+++ b/crates/rustash-core/src/database/mod.rs
@@ -10,12 +10,13 @@ use diesel_migrations::embed_migrations;
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
 // Re-export the migration types for use in backend modules
-pub use diesel_migrations::{AsyncMigrationHarness, EmbeddedMigrations};
+pub use diesel_migrations::EmbeddedMigrations;
 
 #[cfg(feature = "sqlite")]
 pub mod sqlite_pool {
     use super::*;
-    use diesel_async::sqlite::AsyncSqliteConnection;
+    use diesel_async::AsyncSqliteConnection;
+    use diesel_migrations::AsyncMigrationHarness;
 
     pub type SqlitePool = bb8::Pool<
         diesel_async::pooled_connection::AsyncDieselConnectionManager<AsyncSqliteConnection>,
@@ -44,6 +45,7 @@ pub mod sqlite_pool {
 pub mod postgres_pool {
     use super::*;
     use diesel_async::AsyncPgConnection;
+    use diesel_migrations::AsyncMigrationHarness;
 
     pub type PgPool =
         bb8::Pool<diesel_async::pooled_connection::AsyncDieselConnectionManager<AsyncPgConnection>>;

--- a/crates/rustash-core/src/error.rs
+++ b/crates/rustash-core/src/error.rs
@@ -8,9 +8,6 @@ use uuid::Uuid;
 #[cfg(feature = "postgres")]
 use tokio_postgres::error::Error as PgError;
 
-#[cfg(feature = "bb8")]
-use bb8::RunError as Bb8RunError;
-
 /// Result type alias for Rustash operations
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/crates/rustash-core/src/schema.rs
+++ b/crates/rustash-core/src/schema.rs
@@ -29,6 +29,5 @@ diesel::table! {
 }
 
 diesel::joinable!(relations -> snippets (from_uuid));
-diesel::joinable!(vss_snippets -> snippets (rowid));
 
 diesel::allow_tables_to_appear_in_same_query!(relations, snippets, vss_snippets,);

--- a/crates/rustash-core/src/storage/sqlite.rs
+++ b/crates/rustash-core/src/storage/sqlite.rs
@@ -14,8 +14,7 @@ use diesel::{
     sql_types::{Binary as SqlBinary, Double, Integer as SqlInteger, Nullable, Text, Timestamp},
 };
 use diesel_async::{
-    pooled_connection::bb8::PooledConnection, sqlite::AsyncSqliteConnection, AsyncConnection,
-    RunQueryDsl,
+    pooled_connection::bb8::PooledConnection, AsyncConnection, AsyncSqliteConnection, RunQueryDsl,
 };
 use std::sync::Arc;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary
- adjust database pool implementation for new diesel-async imports
- update sqlite backend import path
- update postgres backend implementation
- drop unused bb8 import
- remove unused joinable! macro

## Testing
- `cargo clippy --all -- --deny warnings` *(fails: unresolved imports)*
- `cargo test --workspace --tests` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_b_6875749fb81883308f56670c902a6053