### PR TITLE
[rustash] enable async migrations

### DIFF
--- a/crates/rustash-core/Cargo.toml
+++ b/crates/rustash-core/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 [dependencies]
 # Core
 diesel = { workspace = true, features = ["chrono", "serde_json", "uuid"] }
-diesel_migrations = { workspace = true }
+diesel_migrations = { workspace = true, features = ["async-connection-wrapper"] }
 diesel-async = { version = "0.6.1", default-features = false, features = ["postgres", "sqlite", "bb8"] }
 
 # Serialization

--- a/crates/rustash-core/src/database/mod.rs
+++ b/crates/rustash-core/src/database/mod.rs
@@ -15,7 +15,7 @@ pub use diesel_migrations::EmbeddedMigrations;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_pool {
     use super::*;
-    use diesel_async::AsyncSqliteConnection;
+    use diesel_async::sqlite::AsyncSqliteConnection;
     use diesel_migrations::AsyncMigrationHarness;
 
     pub type SqlitePool = bb8::Pool<

--- a/crates/rustash-core/src/lib.rs
+++ b/crates/rustash-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Rustash Core Library
 
+#![recursion_limit = "256"]
 pub mod config;
 pub mod database;
 pub mod error;

--- a/crates/rustash-core/src/storage/sqlite.rs
+++ b/crates/rustash-core/src/storage/sqlite.rs
@@ -14,7 +14,8 @@ use diesel::{
     sql_types::{Binary as SqlBinary, Double, Integer as SqlInteger, Nullable, Text, Timestamp},
 };
 use diesel_async::{
-    pooled_connection::bb8::PooledConnection, AsyncConnection, AsyncSqliteConnection, RunQueryDsl,
+    pooled_connection::bb8::PooledConnection, sqlite::AsyncSqliteConnection, AsyncConnection,
+    RunQueryDsl,
 };
 use std::sync::Arc;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary
- enable async migrations feature flag
- increase recursion limit
- clarify diesel-async imports

## Testing
- `cargo clippy --all -- --deny warnings` *(fails: failed to select a version for `diesel_migrations`)*
- `cargo test --workspace` *(fails: failed to select a version for `diesel_migrations`)*

------
https://chatgpt.com/codex/tasks/task_b_687587ead3848330ae5af6fee737528d